### PR TITLE
Add script to extract i18n strings

### DIFF
--- a/notesolver/xgettext.sh
+++ b/notesolver/xgettext.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+mkdir -p build/i18n/pot/
+mkdir -p build/i18n/srcFileList/
+find src/ -type f > build/i18n/srcFileList/josm-plugin_noteSolver.txt
+xgettext --from-code=UTF-8 --language=Java --add-comments --sort-output -k -ktrc:1c,2 -kmarktrc:1c,2 -ktr -kmarktr -ktrn:1,2 -ktrnc:1c,2,3 --files-from=build/i18n/srcFileList/josm-plugin_noteSolver.txt --output-dir=build/i18n/pot/


### PR DESCRIPTION
This adds a small sh-script that can extract a *.pot file from the sources, as soon as there are `I18n.tr()` calls. This requires [`xgettext`](https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html) to be installed.

The main command is:
```
xgettext
  --from-code=UTF-8
  --language=Java
  --add-comments
  --sort-output
  -k
  -ktrc:1c,2
  -kmarktrc:1c,2
  -ktr
  -kmarktr
  -ktrn:1,2
  -ktrnc:1c,2,3
  --files-from=build/i18n/srcFileList/josm-plugin_noteSolver.txt
  --output-dir=build/i18n/pot/
```
