### PR TITLE
Calculate proper location for context menu.

### DIFF
--- a/notesolver/src/main/java/org/openstreetmap/josm/plugins/notesolver/NoteSolverPlugin.java
+++ b/notesolver/src/main/java/org/openstreetmap/josm/plugins/notesolver/NoteSolverPlugin.java
@@ -159,13 +159,18 @@ public class NoteSolverPlugin extends Plugin {
 				JPopupMenu contextMenu = new JPopupMenu();
 				for (JMenuItem menuItem : mainMenuEntries(menuTypes.MAIN)) 
 					contextMenu.add(menuItem);
-				Point p = MainApplication.getMainFrame().getMousePosition();
+				Dimension size = contextMenu.getPreferredSize();
+				MainFrame frame = MainApplication.getMainFrame();
+				Point p = frame.getMousePosition();
 				if (p != null) {
 					Component c = MainApplication.getMainFrame().getComponentAt(p);
+					SwingUtilities.convertPointToScreen(p, frame);
 					JComponent jc = (JComponent)c;
 					if (c != null) {
 						contextMenu.setInvoker(c);
-						contextMenu.setLocation(p);
+						// Show menu slightly above the desired location; otherwise we clash with the
+						// note content shown in the map.
+						contextMenu.setLocation(p.x, p.y - size.height - 15);
 						jc.setComponentPopupMenu(contextMenu);
 						contextMenu.setEnabled(true);
 						contextMenu.setVisible(true);


### PR DESCRIPTION
This solves positioning issues with multiple monitors or when the JOSM window isn't maximised on the main display. The code now also evades the node content being shown in the map, which otherwise would have obscured the context menu.

Fixes #20.